### PR TITLE
fix a bug: smtp.port is ignored when smtp.ssl is true

### DIFF
--- a/mail/src/main/scala/info/schleichardt/play2/mailplugin/MailPlugin.scala
+++ b/mail/src/main/scala/info/schleichardt/play2/mailplugin/MailPlugin.scala
@@ -134,8 +134,12 @@ object MailPlugin {
 case class MailConfiguration(host: String, port: Int, useSsl: Boolean, user: Option[String], password: Option[String]) {
   def setup(email: Email): Email = {
     email.setHostName(host)
-    email.setSmtpPort(port)
     email.setSSLOnConnect(useSsl)
+    if (useSsl) {
+      email.setSslSmtpPort(port.toString)
+    } else {
+      email.setSmtpPort(port)
+    }
     email.setAuthentication(user.getOrElse(""), password.getOrElse(""))
     email
   }


### PR DESCRIPTION
if the ssl option is turned on, smpt.port shoud be used for sslSmtpPort.
